### PR TITLE
Add pages-gem to fix dependencies mismatch with github pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'jekyll'
+gem 'github-pages'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,50 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    RedCloth (4.2.9)
+    classifier (1.3.3)
+      fast-stemmer (>= 1.0.0)
+    colorator (0.1)
+    commander (4.1.5)
+      highline (~> 1.6.11)
+    directory_watcher (1.4.1)
+    fast-stemmer (1.0.2)
+    github-pages (6)
+      RedCloth (= 4.2.9)
+      jekyll (= 1.2.1)
+      kramdown (= 1.0.2)
+      liquid (= 2.5.2)
+      maruku (= 0.6.1)
+      rdiscount (= 1.6.8)
+      redcarpet (= 2.3.0)
+    highline (1.6.19)
+    jekyll (1.2.1)
+      classifier (~> 1.3)
+      colorator (~> 0.1)
+      commander (~> 4.1.3)
+      directory_watcher (~> 1.4.1)
+      liquid (~> 2.5.2)
+      maruku (~> 0.5)
+      pygments.rb (~> 0.5.0)
+      redcarpet (~> 2.3.0)
+      safe_yaml (~> 0.7.0)
+    kramdown (1.0.2)
+    liquid (2.5.2)
+    maruku (0.6.1)
+      syntax (>= 1.0.0)
+    posix-spawn (0.3.6)
+    pygments.rb (0.5.2)
+      posix-spawn (~> 0.3.6)
+      yajl-ruby (~> 1.1.0)
+    rdiscount (1.6.8)
+    redcarpet (2.3.0)
+    safe_yaml (0.7.1)
+    syntax (1.0.0)
+    yajl-ruby (1.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  github-pages
+  jekyll


### PR DESCRIPTION
I was having some build issues when pushing to gh-pages, but after following this https://help.github.com/articles/using-jekyll-with-pages#troubleshooting, it was fixed by using the [github-pages gem](https://github.com/github/pages-gem).

I guess is just a matter of enforcing some gem and dependencies versions. But for now it is solved with up-to-date gems.
